### PR TITLE
preventing bloating repl_mon table

### DIFF
--- a/repl_mon.c
+++ b/repl_mon.c
@@ -84,6 +84,14 @@ repl_mon_finish_queries()
     PopActiveSnapshot();
     CommitTransactionCommand();
     pgstat_report_activity(STATE_IDLE, NULL);
+
+    /*
+     * Send statistic about updated table to stats collector
+     * to prevent bloating table. If we don't do this, we
+     * will not know about number of dead tuples in table.
+     * Consequently, autovacuum will not come.
+     */
+    pgstat_report_stat(false);
 }
 
 static void


### PR DESCRIPTION
We must send info about affected tables after each transaction in order to have correct statistic about dead tuples.
