### PR TITLE
Allow zero value for interval setting. Add repl_mon_settings table.

### DIFF
--- a/README
+++ b/README
@@ -9,7 +9,7 @@ It is useful for monitoring replication of PostgreSQL instances:
  - without the need to have superuser option for monitoring user.
 
 This worker can use the following parameters:
- - repl_mon.interval, time (ms) between writing information to table.
+ - repl_mon.interval, time (ms) between writing information to table, default is 1000, set 0 to disable updates.
  - repl_mon.table, name of the table to write data to, default is "repl_mon".
 
 This worker is compatible with PostgreSQL 9.3 and newer versions.

--- a/repl_mon.c
+++ b/repl_mon.c
@@ -136,6 +136,35 @@ repl_mon_init()
             elog(FATAL, "Error while creating table");
     }
 
+    /* Make repl_mon settings visible on replicas */
+    initStringInfo(&buf);
+    appendStringInfo(&buf, "CREATE TABLE IF NOT EXISTS public.%s_settings ("
+                "key TEXT PRIMARY KEY,"
+                "value TEXT NOT NULL)", tablename);
+    pgstat_report_activity(STATE_RUNNING, buf.data);
+    ret = SPI_execute(buf.data, false, 0);
+    if (ret != SPI_OK_UTILITY)
+        elog(FATAL, "Error while creating setting table");
+
+    initStringInfo(&buf);
+    appendStringInfo(&buf, "UPDATE public.%s_settings SET value = '%d' WHERE key = '%s'",
+                tablename, interval, "interval");
+    pgstat_report_activity(STATE_RUNNING, buf.data);
+    ret = SPI_execute(buf.data, false, 0);
+    if (ret != SPI_OK_UPDATE)
+        elog(FATAL, "Error while updating settings table");
+
+    if (SPI_processed == 0)
+    {
+        initStringInfo(&buf);
+        appendStringInfo(&buf, "INSERT INTO public.%s_settings VALUES ('%s', '%d')",
+                tablename, "interval", interval);
+        pgstat_report_activity(STATE_RUNNING, buf.data);
+        ret = SPI_execute(buf.data, false, 0);
+        if (ret != SPI_OK_INSERT)
+            elog(FATAL, "Error while inserting into settings table");
+    }
+
     repl_mon_finish_queries();
 }
 

--- a/repl_mon.c
+++ b/repl_mon.c
@@ -236,7 +236,8 @@ repl_mon_main(Datum main_arg)
         }
 
         /* Main work happens here */
-        repl_mon_update_data();
+        if (interval > 0)
+            repl_mon_update_data();
     }
 
     /* No problems, so clean exit */
@@ -251,7 +252,7 @@ repl_mon_load_params(void)
                             "Default of 1s, max of 300s",
                             &interval,
                             1000,
-                            1,
+                            0,
                             300000,
                             PGC_SIGHUP,
                             GUC_UNIT_MS,


### PR DESCRIPTION
Add table public.repl_mon_interval with current interval setting value. This is useful for monitoring the setting on replicas.