### PR TITLE
Check for interrupts in the main loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 MODULES = repl_mon
+TAP_TESTS = 1
 ifdef USE_PGXS
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/repl_mon.c
+++ b/repl_mon.c
@@ -274,6 +274,8 @@ repl_mon_main(Datum main_arg)
             proc_exit(0);
         }
 
+        CHECK_FOR_INTERRUPTS();
+
         /* Main work happens here */
         if (interval > 0)
             repl_mon_update_data();

--- a/t/001_dropdb.pl
+++ b/t/001_dropdb.pl
@@ -1,0 +1,27 @@
+# Copyright (c) 2024, PostgreSQL Global Development Group
+
+use strict;
+use warnings FATAL => 'all';
+
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+my $node = PostgreSQL::Test::Cluster->new('main');
+
+$node->init;
+$node->append_conf(
+	'postgresql.conf', q{
+shared_preload_libraries = 'repl_mon'
+repl_mon.interval = 0
+});
+$node->start;
+
+# create and drop database
+$node->safe_psql('postgres', 'CREATE DATABASE db1');
+$node->safe_psql('postgres', 'DROP DATABASE db1');
+
+ok(1);
+
+$node->stop;
+done_testing();


### PR DESCRIPTION
Currently if we set repl_mon.interval to 0, DROP DATABASE will hang on waiting for ProcSignalBarrier. Signal processing is done in generic interrupt handler, which is invoked by CHECK_FOR_INTERRUPTS() macro. I've left silent quit and reload for compatibility.